### PR TITLE
feat: [UIE-8090] dbaas suspend and resume on database details and landing page

### DIFF
--- a/packages/api-v4/.changeset/pr-11152-added-1729713487291.md
+++ b/packages/api-v4/.changeset/pr-11152-added-1729713487291.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+DBaaS Suspend and Resume backend calls ([#11152](https://github.com/linode/manager/pull/11152))

--- a/packages/api-v4/src/databases/databases.ts
+++ b/packages/api-v4/src/databases/databases.ts
@@ -301,3 +301,33 @@ export const getSSLFields = (engine: Engine, databaseID: number) =>
     ),
     setMethod('GET')
   );
+
+/**
+ * suspendDatabase
+ *
+ * Suspend the specified database cluster
+ */
+export const suspendDatabase = (engine: Engine, databaseID: number) =>
+  Request<{}>(
+    setURL(
+      `${API_ROOT}/databases/${encodeURIComponent(
+        engine
+      )}/instances/${encodeURIComponent(databaseID)}/suspend`
+    ),
+    setMethod('POST')
+  );
+
+/**
+ * resumeDatabase
+ *
+ * Resume the specified database cluster
+ */
+export const resumeDatabase = (engine: Engine, databaseID: number) =>
+  Request<{}>(
+    setURL(
+      `${API_ROOT}/databases/${encodeURIComponent(
+        engine
+      )}/instances/${encodeURIComponent(databaseID)}/resume`
+    ),
+    setMethod('POST')
+  );

--- a/packages/manager/.changeset/pr-11152-added-1729713452489.md
+++ b/packages/manager/.changeset/pr-11152-added-1729713452489.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+DBaaS Suspend and Resume for Database Landing and Details ([#11152](https://github.com/linode/manager/pull/11152))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 
 import { databaseFactory } from 'src/factories/databases';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import DatabaseSettings from './DatabaseSettings';
+import * as utils from '../../utilities';
+
+beforeAll(() => mockMatchMedia());
 
 describe('DatabaseSettings Component', () => {
   const database = databaseFactory.build();
@@ -19,6 +22,7 @@ describe('DatabaseSettings Component', () => {
     const paper = container.querySelector('.MuiPaper-root');
     expect(paper).not.toBeNull();
     const headings = getAllByRole('heading');
+
     expect(headings[0].textContent).toBe('Access Controls');
     expect(headings[1].textContent).toBe('Reset Root Password');
     expect(headings[2].textContent).toBe('Delete Cluster');
@@ -69,5 +73,107 @@ describe('DatabaseSettings Component', () => {
     expect(queryByText('Monthly')).toBeNull();
     expect(queryByText('Weekly')).toBeNull();
     expect(queryByText('Set a Weekly Maintenance Window')).toBeTruthy();
+  });
+
+  it('should render suspend option when isDatabasesV2GA flag is true', async () => {
+    const flags = {
+      dbaasV2: {
+        beta: false,
+        enabled: true,
+      },
+    };
+    const mockNewDatabase = databaseFactory.build({
+      platform: 'rdbms-default',
+    });
+
+    const spy = vi.spyOn(utils, 'useIsDatabasesEnabled');
+    spy.mockReturnValue({
+      isDatabasesEnabled: true,
+      isDatabasesV1Enabled: true,
+      isDatabasesV2Beta: false,
+      isDatabasesV2Enabled: true,
+      isDatabasesV2GA: true,
+      isUserExistingBeta: false,
+      isUserNewBeta: false,
+    });
+
+    const { container, getAllByRole } = renderWithTheme(
+      <DatabaseSettings database={mockNewDatabase} />,
+      { flags }
+    );
+    const paper = container.querySelector('.MuiPaper-root');
+    expect(paper).not.toBeNull();
+    const headings = getAllByRole('heading');
+
+    expect(headings[0].textContent).toBe('Suspend Cluster');
+    expect(headings[1].textContent).toBe('Access Controls');
+    expect(headings[2].textContent).toBe('Reset Root Password');
+    expect(headings[3].textContent).toBe('Delete Cluster');
+  });
+
+  it('should disable suspend when database status is not active', async () => {
+    const flags = {
+      dbaasV2: {
+        beta: false,
+        enabled: true,
+      },
+    };
+    const mockNewDatabase = databaseFactory.build({
+      platform: 'rdbms-default',
+      status: 'resizing',
+    });
+
+    const spy = vi.spyOn(utils, 'useIsDatabasesEnabled');
+    spy.mockReturnValue({
+      isDatabasesEnabled: true,
+      isDatabasesV1Enabled: true,
+      isDatabasesV2Beta: false,
+      isDatabasesV2Enabled: true,
+      isDatabasesV2GA: true,
+      isUserExistingBeta: false,
+      isUserNewBeta: false,
+    });
+
+    const { getAllByText } = renderWithTheme(
+      <DatabaseSettings database={mockNewDatabase} />,
+      { flags }
+    );
+
+    const suspendElements = getAllByText(/Suspend Cluster/i);
+    const suspendButton = suspendElements[1].closest('button');
+    expect(suspendButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable suspend when database status is active', async () => {
+    const flags = {
+      dbaasV2: {
+        beta: false,
+        enabled: true,
+      },
+    };
+    const mockNewDatabase = databaseFactory.build({
+      platform: 'rdbms-default',
+      status: 'active',
+    });
+
+    const spy = vi.spyOn(utils, 'useIsDatabasesEnabled');
+    spy.mockReturnValue({
+      isDatabasesEnabled: true,
+      isDatabasesV1Enabled: true,
+      isDatabasesV2Beta: false,
+      isDatabasesV2Enabled: true,
+      isDatabasesV2GA: true,
+      isUserExistingBeta: false,
+      isUserNewBeta: false,
+    });
+
+    const { getAllByText } = renderWithTheme(
+      <DatabaseSettings database={mockNewDatabase} />,
+      { flags }
+    );
+
+    const suspendElements = getAllByText(/Suspend Cluster/i);
+    const suspendButton = suspendElements[1].closest('button');
+    expect(suspendButton).toHaveAttribute('aria-disabled', 'false');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -135,15 +135,13 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
         onClose={onResetRootPasswordClose}
         open={isResetRootPasswordDialogOpen}
       />
-      {isDatabasesV2GA && isDefault ? (
-        <DatabaseSettingsSuspendClusterDialog
-          databaseEngine={database.engine}
-          databaseId={database.id}
-          databaseLabel={database.label}
-          onClose={onSuspendDialogClose}
-          open={isSuspendClusterDialogOpen}
-        />
-      ) : null}
+      <DatabaseSettingsSuspendClusterDialog
+        databaseEngine={database.engine}
+        databaseId={database.id}
+        databaseLabel={database.label}
+        onClose={onSuspendDialogClose}
+        open={isSuspendClusterDialogOpen}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -12,6 +12,8 @@ import DatabaseSettingsResetPasswordDialog from './DatabaseSettingsResetPassword
 import MaintenanceWindow from './MaintenanceWindow';
 
 import type { Database } from '@linode/api-v4/lib/databases/types';
+import { DatabaseSettingsSuspendClusterDialog } from './DatabaseSettingsSuspendClusterDialog';
+import { useIsDatabasesEnabled } from '../../utilities';
 
 interface Props {
   database: Database;
@@ -21,6 +23,7 @@ interface Props {
 export const DatabaseSettings: React.FC<Props> = (props) => {
   const { database, disabled } = props;
   const { data: profile } = useProfile();
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const accessControlCopy = (
     <Typography>
@@ -30,6 +33,9 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
   );
 
   const isLegacy = database.platform === 'rdbms-legacy';
+  const isDefault = database.platform === 'rdbms-default';
+
+  const suspendClusterCopy = `Suspend the cluster if you don't use it temporarily to prevent being billed for it.`;
 
   const resetRootPasswordCopy = isLegacy
     ? 'Resetting your root password will automatically generate a new password. You can view the updated password on your database cluster summary page. '
@@ -44,6 +50,10 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
     isResetRootPasswordDialogOpen,
     setIsResetRootPasswordDialogOpen,
   ] = React.useState(false);
+  const [
+    isSuspendClusterDialogOpen,
+    setIsSuspendClusterDialogOpen,
+  ] = React.useState(false);
 
   const onResetRootPassword = () => {
     setIsResetRootPasswordDialogOpen(true);
@@ -51,6 +61,10 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
 
   const onDeleteCluster = () => {
     setIsDeleteDialogOpen(true);
+  };
+
+  const onSuspendCluster = () => {
+    setIsSuspendClusterDialogOpen(true);
   };
 
   const onDeleteClusterClose = () => {
@@ -61,9 +75,25 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
     setIsResetRootPasswordDialogOpen(false);
   };
 
+  const onSuspendDialogClose = () => {
+    setIsSuspendClusterDialogOpen(false);
+  };
+
   return (
     <>
       <Paper>
+        {isDatabasesV2GA && isDefault && (
+          <>
+            <DatabaseSettingsMenuItem
+              buttonText={'Suspend Cluster'}
+              descriptiveText={suspendClusterCopy}
+              disabled={disabled || database.status !== 'active'}
+              onClick={onSuspendCluster}
+              sectionTitle={'Suspend Cluster'}
+            />
+            <Divider spacingBottom={22} spacingTop={28} />
+          </>
+        )}
         <AccessControls
           database={database}
           description={accessControlCopy}
@@ -105,6 +135,15 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
         onClose={onResetRootPasswordClose}
         open={isResetRootPasswordDialogOpen}
       />
+      {isDatabasesV2GA && isDefault ? (
+        <DatabaseSettingsSuspendClusterDialog
+          databaseEngine={database.engine}
+          databaseId={database.id}
+          databaseLabel={database.label}
+          onClose={onSuspendDialogClose}
+          open={isSuspendClusterDialogOpen}
+        />
+      ) : null}
     </>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.test.tsx
@@ -1,0 +1,86 @@
+import { waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import {
+  DatabaseSettingsSuspendClusterDialog,
+  SuspendDialogProps,
+} from './DatabaseSettingsSuspendClusterDialog';
+import { Engine } from '@linode/api-v4';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse, server } from 'src/mocks/testServer';
+
+const mockEngine: Engine = 'mysql';
+const mockLabel = 'database-1';
+const props: SuspendDialogProps = {
+  databaseEngine: mockEngine,
+  databaseId: 1234,
+  databaseLabel: mockLabel,
+  onClose: vi.fn(),
+  open: true,
+};
+
+describe('DatabaseSettingsSuspendClusterDialog', () => {
+  it('renders the dialog with text', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <DatabaseSettingsSuspendClusterDialog {...props} />
+    );
+    expect(getByText(`Suspend ${mockLabel} cluster?`)).toBeVisible();
+    expect(getByText('Suspend Cluster')).toBeVisible();
+    expect(getByTestId('CloseIcon')).toBeVisible();
+  });
+
+  it('should initialize with unchecked checkbox and disabled submit button', async () => {
+    const { getByRole, getByText } = renderWithTheme(
+      <DatabaseSettingsSuspendClusterDialog {...props} />
+    );
+    const confirmationCheckbox = getByRole('checkbox') as HTMLInputElement;
+    const suspendButton = getByText(/Suspend Cluster/i).closest('button');
+    expect(confirmationCheckbox.checked).toBeFalsy();
+    expect(suspendButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable submit button when checkbox is checked', async () => {
+    const { getByRole, getByText } = renderWithTheme(
+      <DatabaseSettingsSuspendClusterDialog {...props} />
+    );
+    const confirmationCheckbox = getByRole('checkbox') as HTMLInputElement;
+    const suspendButton = getByText(/Suspend Cluster/i).closest('button');
+    await userEvent.click(confirmationCheckbox);
+    expect(confirmationCheckbox.checked).toBeTruthy();
+    expect(suspendButton).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('should call onClose after suspend call is successful', async () => {
+    server.use(
+      http.post(`*/databases/${encodeURIComponent(mockEngine)}/suspend`, () => {
+        return HttpResponse.json({});
+      })
+    );
+    const { getByText, getByRole } = renderWithTheme(
+      <DatabaseSettingsSuspendClusterDialog {...props} />
+    );
+    const confirmationCheckbox = getByRole('checkbox') as HTMLInputElement;
+    const suspendButton = getByText(/Suspend Cluster/i).closest(
+      'button'
+    ) as HTMLButtonElement;
+
+    await userEvent.click(confirmationCheckbox);
+    await userEvent.click(suspendButton);
+    await waitFor(() => {
+      expect(props.onClose).toBeCalled();
+    });
+  });
+
+  it('closes the confirmaton dialog if the X button is clicked', async () => {
+    const { getByTestId } = renderWithTheme(
+      <DatabaseSettingsSuspendClusterDialog {...props} />
+    );
+
+    const closeButton = getByTestId('CloseIcon');
+    expect(closeButton).toBeVisible();
+
+    await userEvent.click(closeButton);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
@@ -1,0 +1,101 @@
+import { Engine } from '@linode/api-v4/lib/databases';
+import { useSnackbar } from 'notistack';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Checkbox } from 'src/components/Checkbox';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { Notice } from 'src/components/Notice/Notice';
+import { Typography } from 'src/components/Typography';
+import { useSuspendDatabaseMutation } from 'src/queries/databases/databases';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+export interface SuspendDialogProps {
+  databaseEngine: Engine;
+  databaseId: number;
+  databaseLabel: string;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const DatabaseSettingsSuspendClusterDialog = (
+  props: SuspendDialogProps
+) => {
+  const { databaseEngine, databaseId, databaseLabel, onClose, open } = props;
+  const { enqueueSnackbar } = useSnackbar();
+  const {
+    mutateAsync: suspendDatabase,
+    isPending,
+    error,
+    reset,
+  } = useSuspendDatabaseMutation(databaseEngine, databaseId);
+
+  const defaultError = 'There was an error suspending this Database Cluster.';
+  const [hasConfirmed, setHasConfirmed] = React.useState(false);
+  const { push } = useHistory();
+
+  const onSuspendCluster = () => {
+    suspendDatabase()
+      .then(() => {
+        enqueueSnackbar('Database Cluster suspended successfully.', {
+          variant: 'success',
+        });
+        onClose();
+        setHasConfirmed(false);
+        push('/databases');
+      })
+      .catch(() => {
+        setHasConfirmed(false);
+      });
+  };
+
+  const onCancel = () => {
+    onClose();
+    reset();
+    setHasConfirmed(false);
+  };
+
+  const suspendClusterCopy = `A suspended cluster stops working immediately and you won't be billed for it.
+    You can resume the clusters work within 180 days from its suspension.
+    After that time, the cluster will be deleted permanently.`;
+
+  const actions = (
+    <ActionsPanel
+      primaryButtonProps={{
+        disabled: !hasConfirmed,
+        label: 'Suspend Cluster',
+        loading: isPending,
+        onClick: onSuspendCluster,
+      }}
+      secondaryButtonProps={{
+        label: 'Cancel',
+        onClick: onCancel,
+      }}
+      style={{ padding: 0 }}
+    />
+  );
+
+  return (
+    <ConfirmationDialog
+      error={
+        error ? getAPIErrorOrDefault(error, defaultError)[0].reason : undefined
+      }
+      actions={actions}
+      maxWidth="sm"
+      onClose={onClose}
+      open={open}
+      title={`Suspend ${databaseLabel} cluster?`}
+    >
+      <Notice variant="warning">
+        <Typography style={{ fontSize: '0.875rem' }}>
+          <b>{suspendClusterCopy}</b>
+        </Typography>
+      </Notice>
+      <Checkbox
+        checked={hasConfirmed}
+        onChange={() => setHasConfirmed((confirmed) => !confirmed)}
+        text="I understand the effects of this action."
+      />
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
@@ -34,19 +34,21 @@ export const DatabaseSettingsSuspendClusterDialog = (
   const [hasConfirmed, setHasConfirmed] = React.useState(false);
   const { push } = useHistory();
 
-  const onSuspendCluster = () => {
-    suspendDatabase()
-      .then(() => {
-        enqueueSnackbar('Database Cluster suspended successfully.', {
-          variant: 'success',
-        });
-        onClose();
-        setHasConfirmed(false);
-        push('/databases');
-      })
-      .catch(() => {
-        setHasConfirmed(false);
+  const onSuspendCluster = async () => {
+    try {
+      await suspendDatabase();
+      enqueueSnackbar('Database Cluster suspended successfully.', {
+        variant: 'success',
       });
+      onClose();
+      push('/databases');
+    } catch (error) {
+      enqueueSnackbar('Failed to suspend Database Cluster. Please try again.', {
+        variant: 'error',
+      });
+    } finally {
+      setHasConfirmed(false);
+    }
   };
 
   const onCancel = () => {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
@@ -9,7 +9,6 @@ import { useIsDatabasesEnabled } from '../utilities';
 import { useResumeDatabaseMutation } from 'src/queries/databases/databases';
 import { enqueueSnackbar } from 'notistack';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { APIError } from '@linode/api-v4/src/types';
 
 interface Props {
   databaseEngine: Engine;
@@ -48,21 +47,19 @@ export const DatabaseActionMenu = (props: Props) => {
 
   const history = useHistory();
 
-  const handleResume = () => {
-    resumeDatabase()
-      .then(() => {
-        enqueueSnackbar('Database Cluster resumed successfully.', {
-          variant: 'success',
-        });
-      })
-      .catch((e: APIError[]) => {
-        const defaultError =
-          'There was an error resuming this Database Cluster.';
-        const error = getAPIErrorOrDefault(e, defaultError)[0].reason;
-        enqueueSnackbar(error, {
-          variant: 'error',
-        });
+  const handleResume = async () => {
+    try {
+      await resumeDatabase();
+      return enqueueSnackbar('Database Cluster resumed successfully.', {
+        variant: 'success',
       });
+    } catch (e: any) {
+      const error = getAPIErrorOrDefault(
+        e,
+        'There was an error resuming this Database Cluster.'
+      )[0].reason;
+      return enqueueSnackbar(error, { variant: 'error' });
+    }
   };
 
   const actions: Action[] = [

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
@@ -3,36 +3,69 @@ import { useHistory } from 'react-router-dom';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 
-import type { Engine } from '@linode/api-v4';
+import type { DatabaseStatus, Engine } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
+import { useIsDatabasesEnabled } from '../utilities';
+import { useResumeDatabaseMutation } from 'src/queries/databases/databases';
+import { enqueueSnackbar } from 'notistack';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { APIError } from '@linode/api-v4/src/types';
 
 interface Props {
   databaseEngine: Engine;
   databaseId: number;
   databaseLabel: string;
   handlers: ActionHandlers;
+  databaseStatus: DatabaseStatus;
 }
 
 export interface ActionHandlers {
   handleDelete: () => void;
   handleManageAccessControls: () => void;
   handleResetPassword: () => void;
+  handleSuspend: () => void;
 }
 
 export const DatabaseActionMenu = (props: Props) => {
-  const { databaseEngine, databaseId, databaseLabel, handlers } = props;
+  const {
+    databaseEngine,
+    databaseId,
+    databaseLabel,
+    handlers,
+    databaseStatus,
+  } = props;
 
-  const databaseStatus = 'running';
-  const isDatabaseNotRunning = databaseStatus !== 'running';
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
+  const { mutateAsync: resumeDatabase } = useResumeDatabaseMutation(
+    databaseEngine,
+    databaseId
+  );
+
+  const status = 'running';
+  const isDatabaseNotRunning = status !== 'running';
+  const isDatabaseSuspended =
+    databaseStatus === 'suspended' || databaseStatus === 'suspending';
 
   const history = useHistory();
 
+  const handleResume = () => {
+    resumeDatabase()
+      .then(() => {
+        enqueueSnackbar('Database Cluster resumed successfully.', {
+          variant: 'success',
+        });
+      })
+      .catch((e: APIError[]) => {
+        const defaultError =
+          'There was an error resuming this Database Cluster.';
+        const error = getAPIErrorOrDefault(e, defaultError)[0].reason;
+        enqueueSnackbar(error, {
+          variant: 'error',
+        });
+      });
+  };
+
   const actions: Action[] = [
-    // TODO: add suspend action menu item once it's ready
-    // {
-    //   onClick: () => {},
-    //   title: databaseStatus === 'running' ? 'Suspend' : 'Power On',
-    // },
     {
       disabled: isDatabaseNotRunning,
       onClick: handlers.handleManageAccessControls,
@@ -58,6 +91,24 @@ export const DatabaseActionMenu = (props: Props) => {
       title: 'Delete',
     },
   ];
+
+  if (isDatabasesV2GA) {
+    actions.unshift({
+      disabled: databaseStatus !== 'active',
+      onClick: () => {
+        handlers.handleSuspend();
+      },
+      title: 'Suspend',
+    });
+
+    actions.splice(4, 0, {
+      disabled: !isDatabaseSuspended,
+      onClick: () => {
+        handleResume();
+      },
+      title: 'Resume',
+    });
+  }
 
   return (
     <ActionMenu

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -137,6 +137,7 @@ const DatabaseLanding = () => {
   const isV2Enabled = isDatabasesV2Enabled || isDatabasesV2GA;
   const showTabs = isV2Enabled && !!legacyDatabases?.data.length;
   const isNewDatabase = isV2Enabled && !!newDatabases?.data.length;
+  const showSuspend = isDatabasesV2GA && !!newDatabases?.data.length;
 
   const legacyTable = () => {
     return (
@@ -155,6 +156,7 @@ const DatabaseLanding = () => {
         data={newDatabases?.data}
         handleOrderChange={newDatabaseHandleOrderChange}
         isNewDatabase={true}
+        showSuspend={showSuspend}
         order={newDatabaseOrder}
         orderBy={newDatabaseOrderBy}
       />

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
@@ -219,15 +219,13 @@ const DatabaseLandingTable = ({
           )}
         </>
       )}
-      {showSuspend && (
-        <DatabaseSettingsSuspendClusterDialog
-          databaseEngine={selectedDatabase.engine}
-          databaseId={selectedDatabase.id}
-          databaseLabel={selectedDatabase.label}
-          onClose={() => setIsSuspendClusterDialogOpen(false)}
-          open={isSuspendClusterDialogOpen}
-        />
-      )}
+      <DatabaseSettingsSuspendClusterDialog
+        databaseEngine={selectedDatabase.engine}
+        databaseId={selectedDatabase.id}
+        databaseLabel={selectedDatabase.label}
+        onClose={() => setIsSuspendClusterDialogOpen(false)}
+        open={isSuspendClusterDialogOpen}
+      />
       <AddAccessControlDrawer
         database={selectedDatabase}
         onClose={onCloseAccesControls}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
@@ -20,6 +20,7 @@ import { useInProgressEvents } from 'src/queries/events/events';
 
 import type { DatabaseInstance } from '@linode/api-v4/lib/databases';
 import type { Order } from 'src/hooks/useOrder';
+import { DatabaseSettingsSuspendClusterDialog } from '../DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog';
 
 const preferenceKey = 'databases';
 
@@ -29,6 +30,7 @@ interface Props {
   isNewDatabase?: boolean;
   order: 'asc' | 'desc';
   orderBy: string;
+  showSuspend?: boolean;
 }
 const DatabaseLandingTable = ({
   data,
@@ -36,6 +38,7 @@ const DatabaseLandingTable = ({
   isNewDatabase,
   order,
   orderBy,
+  showSuspend,
 }: Props) => {
   const { data: events } = useInProgressEvents();
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
@@ -56,6 +59,10 @@ const DatabaseLandingTable = ({
     isManageAccessControlsDialogOpen,
     setIsManageAccessControlsDialogOpen,
   ] = React.useState(false);
+  const [
+    isSuspendClusterDialogOpen,
+    setIsSuspendClusterDialogOpen,
+  ] = React.useState(false);
 
   const handleManageAccessControls = (database: DatabaseInstance) => {
     setSelectedDatabase(database);
@@ -75,6 +82,11 @@ const DatabaseLandingTable = ({
   const handleResetPassword = (database: DatabaseInstance) => {
     setSelectedDatabase(database);
     setIsResetPasswordsDialogOpen(true);
+  };
+
+  const handleSuspend = (database: DatabaseInstance) => {
+    setSelectedDatabase(database);
+    setIsSuspendClusterDialogOpen(true);
   };
 
   return (
@@ -157,6 +169,7 @@ const DatabaseLandingTable = ({
                 handleManageAccessControls: () =>
                   handleManageAccessControls(database),
                 handleResetPassword: () => handleResetPassword(database),
+                handleSuspend: () => handleSuspend(database),
               }}
               database={database}
               events={events}
@@ -205,6 +218,15 @@ const DatabaseLandingTable = ({
             </>
           )}
         </>
+      )}
+      {showSuspend && (
+        <DatabaseSettingsSuspendClusterDialog
+          databaseEngine={selectedDatabase.engine}
+          databaseId={selectedDatabase.id}
+          databaseLabel={selectedDatabase.label}
+          onClose={() => setIsSuspendClusterDialogOpen(false)}
+          open={isSuspendClusterDialogOpen}
+        />
       )}
       <AddAccessControlDrawer
         database={selectedDatabase}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -54,6 +54,7 @@ export const DatabaseRow = ({
     id,
     label,
     region,
+    status,
     type,
     version,
   } = database;
@@ -66,6 +67,8 @@ export const DatabaseRow = ({
   const plan = types?.find((t: DatabaseType) => t.id === type);
   const formattedPlan = plan && formatStorageUnits(plan.label);
   const actualRegion = regions?.find((r) => r.id === region);
+  const isLinkInactive =
+    status === 'suspended' || status === 'suspending' || status === 'resuming';
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const configuration =
@@ -85,7 +88,11 @@ export const DatabaseRow = ({
   return (
     <TableRow data-qa-database-cluster-id={id} key={`database-row-${id}`}>
       <TableCell>
-        <Link to={`/databases/${engine}/${id}`}>{label}</Link>
+        {isDatabasesV2GA && isLinkInactive ? (
+          label
+        ) : (
+          <Link to={`/databases/${engine}/${id}`}>{label}</Link>
+        )}
       </TableCell>
       <TableCell statusCell>
         <DatabaseStatusDisplay database={database} events={events} />
@@ -110,6 +117,7 @@ export const DatabaseRow = ({
       {isDatabasesV2GA && isNewDatabase && (
         <TableCell actionCell>
           <DatabaseActionMenu
+            databaseStatus={status}
             databaseEngine={engine}
             databaseId={id}
             databaseLabel={label}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -324,6 +324,14 @@ const databases = [
   http.delete('*/databases/mysql/instances/:databaseId', () => {
     return HttpResponse.json({});
   }),
+
+  http.post('*/databases/:engine/instances/:databaseId/suspend', () => {
+    return HttpResponse.json({});
+  }),
+
+  http.post('*/databases/:engine/instances/:databaseId/resume', () => {
+    return HttpResponse.json({});
+  }),
 ];
 
 const vpc = [

--- a/packages/manager/src/queries/databases/databases.ts
+++ b/packages/manager/src/queries/databases/databases.ts
@@ -8,6 +8,8 @@ import {
   legacyRestoreWithBackup,
   resetDatabaseCredentials,
   restoreWithBackup,
+  resumeDatabase,
+  suspendDatabase,
   updateDatabase,
 } from '@linode/api-v4/lib/databases';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
@@ -165,6 +167,36 @@ export const useDeleteDatabaseMutation = (engine: Engine, id: number) => {
         queryKey: databaseQueries.databases.queryKey,
       });
       queryClient.removeQueries({
+        queryKey: databaseQueries.database(engine, id).queryKey,
+      });
+    },
+  });
+};
+
+export const useSuspendDatabaseMutation = (engine: Engine, id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[]>({
+    mutationFn: () => suspendDatabase(engine, id),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: databaseQueries.databases.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: databaseQueries.database(engine, id).queryKey,
+      });
+    },
+  });
+};
+
+export const useResumeDatabaseMutation = (engine: Engine, id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[]>({
+    mutationFn: () => resumeDatabase(engine, id),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: databaseQueries.databases.queryKey,
+      });
+      queryClient.invalidateQueries({
         queryKey: databaseQueries.database(engine, id).queryKey,
       });
     },


### PR DESCRIPTION
## Description 📝
Adding Suspend and Resume functionality to Landing Page and database details Settings Views for GA

## Changes  🔄
Mostly taking smans branch but updating while he is on vacation to address PR feedback.

## Target release date 🗓️
11/12/2024

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/143744a6-ec28-49c1-8a2f-b5e3e9259f2e) | ![image](https://github.com/user-attachments/assets/e5d73fc7-9c8d-4602-aad5-a42f4e9785fb) |
| ![image](https://github.com/user-attachments/assets/ed238c6a-5494-4827-9936-c3473c92ef90)| ![image](https://github.com/user-attachments/assets/1170985f-2da3-4d51-b9af-7e7d434fcf85)|
| | ![image](https://github.com/user-attachments/assets/a86873bd-582a-4fd6-a3a4-0edcf04c0669)|
## How to test 🧪

### Prerequisites
- Managed Databases account capability
- LD flag: beta: false, enabled: true

### Verification steps
- Toggle LD will show Suspend and resume functionality
- Check DatabaseSettings to see new Suspend Button and Dialog behavior
- Check DatabaseLanding to see new suspend and resume actions
- Check DatabaseLanding to confirm that Suspend can only be used on active databases
- Check DatabaseLanding to confirm that the resume action can only be used on Suspending and Suspended database clusters
- Check DatabaseLanding to confirm that clusters with suspending, suspended, and resuming status do not have detail links under Cluster Label column

## As an Author I have considered 🤔

*Check all that apply*

- [x ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
